### PR TITLE
Create .gitattributes to highlight Noir code as Rust

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.nr linguist-language=Rust


### PR DESCRIPTION
This _should_ highlight the Noir code as Rust